### PR TITLE
 Implemented Samples.credibility_interval 2.0 (#188 adapted for anesthetic 2.0)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,14 +2,17 @@ import warnings
 import numpy as np
 import pytest
 from scipy import special as sp
-from numpy.testing import assert_array_equal
+
+from numpy.testing import (assert_array_equal, assert_allclose,
+                           assert_array_almost_equal)
 from anesthetic import read_chains
 from anesthetic.utils import (nest_level, compute_nlive, unique, is_int,
                               iso_probability_contours,
                               iso_probability_contours_from_samples,
                               logsumexp, sample_compression_1d,
                               triangular_sample_compression_2d,
-                              insertion_p_value, compress_weights)
+                              insertion_p_value, compress_weights,
+                              credibility_interval, cdf)
 
 
 def test_compress_weights():
@@ -172,3 +175,54 @@ def test_p_values_from_sample():
 
     ks_results = insertion_p_value(ns.insertion[nlive:-nlive], nlive, batch=1)
     assert ks_results['p-value'] > 0.05
+
+
+
+def test_cdf():
+    np.random.seed(3)
+    data = np.random.randn(10000)
+    weights = np.random.rand(10000)
+
+    CDF = cdf(data, weights)
+    ICDF = cdf(data, weights, inverse=True)
+
+    linspace = np.linspace(0, 1, 1001)[1:-1]
+    assert_array_almost_equal(linspace, CDF(ICDF(linspace)))
+
+    sigs = [CDF(i)-CDF(-i) for i in [1, 2, 3]]
+    assert_allclose(sigs, [0.6827, 0.9545, 0.9973], atol=0.01)
+
+
+def test_credibility_interval():
+    np.random.seed(0)
+    from anesthetic import read_chains
+    from anesthetic.utils import credibility_interval
+    samples = read_chains('./tests/example_data/pc')
+    mean, std = credibility_interval(samples["x0"], level=0.68,
+                    weights=samples.get_weights(), method="hpd",
+                    u=np.random.rand(len(samples)))
+    assert_allclose(mean[0], -0.1, atol=0.01)
+    assert_allclose(mean[1], 0.1, atol=0.01)
+    assert_allclose(std[0], 0.015, atol=0.001)
+    assert_allclose(std[1], 0.015, atol=0.001)
+    #assert_allclose(credibility_interval(samples["x0"], level=0.95,
+    #                weights=samples.weights, method="et"),
+    #                [-0.2, 0.2], atol=0.02)
+    #assert_allclose(credibility_interval(samples["x0"], level=0.975,
+    #                weights=samples.weights, method="ul"),
+    #                0.2, atol=0.02)
+    #assert_allclose(credibility_interval(samples["x0"], level=0.5,
+    #                weights=samples.weights, method="ll"),
+    #                0, atol=0.001)
+
+    with pytest.raises(ValueError):
+        credibility_interval(samples.x0, level=1.1)
+
+    with pytest.raises(ValueError):
+        credibility_interval(samples[['x0', 'x1']])
+
+    with pytest.raises(ValueError):
+        credibility_interval(samples.x0, weights=[1, 2, 3])
+
+    with pytest.raises(ValueError):
+        credibility_interval(samples.x0, method='foo')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -178,25 +178,16 @@ def test_p_values_from_sample():
 
 
 
-def test_cdf():
-    np.random.seed(3)
-    data = np.random.randn(10000)
-    weights = np.random.rand(10000)
-
-    CDF = cdf(data, weights)
-    ICDF = cdf(data, weights, inverse=True)
-
-    linspace = np.linspace(0, 1, 1001)[1:-1]
-    assert_array_almost_equal(linspace, CDF(ICDF(linspace)))
-
-    sigs = [CDF(i)-CDF(-i) for i in [1, 2, 3]]
-    assert_allclose(sigs, [0.6827, 0.9545, 0.9973], atol=0.01)
-
-
 def test_credibility_interval():
     np.random.seed(0)
     from anesthetic import read_chains
     from anesthetic.utils import credibility_interval
+    normal_samples = np.random.normal(loc=2, scale=0.1, size=10000)
+    mean, std = credibility_interval(normal_samples, level=0.68)
+    print(mean, std)
+    assert_allclose(mean[0], 1.9, atol=0.01)
+    assert_allclose(mean[1], 2.1, atol=0.01)
+
     samples = read_chains('./tests/example_data/pc')
     mean, std = credibility_interval(samples["x0"], level=0.68,
                     weights=samples.get_weights(), method="hpd",


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both README.rst and anesthetic/_version.py

# Tests

Test correct result for Gaussian:
```
means = [[], []]
    stds = [[], []]
    for i in range(1000):
        samples = np.random.normal(loc=2, scale=0.1, size=10000)
        mean, std = credibility_interval(samples, level=0.68)
        means[0].append(mean[0])
        means[1].append(mean[1])
        stds[0].append(std[0])
        stds[1].append(std[1])
    import matplotlib.pyplot as plt
    plt.hist(means[0], bins=100, histtype='step', label='lower')
    plt.legend()
    plt.show()
    print("Mean = ", np.mean(means[0]), "+/-", np.std(means[0]))
    print("Std = ", np.mean(stds[0])
```

# Questions

I considered adding a test iff user passes a `NestedSamples` or `MCMCSamples` object then check that they passed the right weights. This would introduce the first anesthetic import into `utils.py` so wanted to double check.
```
# Check if samples is NestedSamples object
if type(samples) == NestedSamples:
    if weights is None:
        assert samples.get_weights() == np.ones(len(samples))
    else:
        assert np.allclose(weights, samples.get_weights())
```

# Notes

Will potentially make a separate PR to implement this method into existing `quantile()` function
```
def cdf(a, w=None, inverse=False, interpolation='linear'):
    """Compute the weighted (inverse) empirical cdf for a 1d array."""
    if w is None:
        w = np.ones_like(a)
    a = np.array(list(a))  # Necessary to convert pandas arrays
    w = np.array(list(w))  # Necessary to convert pandas arrays
    i = np.argsort(a)
    c = np.cumsum(w[i[1:]]+w[i[:-1]])
    c = c / c[-1]
    c = np.concatenate(([0.], c))
    if inverse:
        return interp1d(c, a[i], kind=interpolation)
    else:
        return interp1d(a[i], c, kind=interpolation)


def quantile(a, q, w=None, interpolation='linear'):
    """Compute the weighted quantile for a one dimensional array."""
    icdf = cdf(a, w, inverse=True, interpolation=interpolation)
    quant = icdf(q)
    if isinstance(q, float):
        quant = float(quant)
    return quant
```

```

def test_cdf():
    np.random.seed(3)
    data = np.random.randn(10000)
    weights = np.random.rand(10000)

    CDF = cdf(data, weights)
    ICDF = cdf(data, weights, inverse=True)

    linspace = np.linspace(0, 1, 1001)[1:-1]
    assert_array_almost_equal(linspace, CDF(ICDF(linspace)))

    sigs = [CDF(i)-CDF(-i) for i in [1, 2, 3]]
    assert_allclose(sigs, [0.6827, 0.9545, 0.9973], atol=0.01)
```