### PR TITLE
rename `[test]` optional dependency to `[tests]`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ You can check that things are working by running the test suite:
 .. code:: bash
 
     export MPLBACKEND=Agg     # only necessary for OSX users
-    python -m pip install ".[test]"
+    python -m pip install ".[tests]"
     python -m pytest
     flake8 anesthetic tests
     pydocstyle --convention=numpy anesthetic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 
 [project.optional-dependencies]
 docs = ["sphinx", "sphinx_rtd_theme", "numpydoc"]
-test = ["pytest", "pytest-cov", "flake8", "pydocstyle", "packaging", "pre-commit"]
+tests = ["pytest", "pytest-cov", "flake8", "pydocstyle", "packaging", "pre-commit"]
 astropy = ["astropy"]
 fastkde = ["fastkde"]
 getdist = ["getdist"]


### PR DESCRIPTION
# Description

Quick one, I find it quite strange we have plural `extras` but singular `test` optional dependencies, so I've changed it to `tests`

Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both README.rst and anesthetic/_version.py
