### PR TITLE
remove show-inheritance from anesthetic.core to see if this fixes docs

### DIFF
--- a/docs/source/anesthetic.rst
+++ b/docs/source/anesthetic.rst
@@ -57,7 +57,6 @@ anesthetic.core module
 .. automodule:: anesthetic.core
    :members:
    :undoc-members:
-   :show-inheritance:
 
 
 anesthetic.scripts module


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both README.rst and anesthetic/_version.py
