### PR TITLE
rasterize scatter in plot_2d

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -245,7 +245,7 @@ class Samples(WeightedLabelledDataFrame):
 
         return axes
 
-    def plot_2d(self, axes=None, *args, **kwargs):
+    def plot_2d(self, axes=None, rasterize_scatter=False, *args, **kwargs):
         """Create an array of 2D plots.
 
         To avoid interfering with y-axis sharing, one-dimensional plots are
@@ -269,6 +269,12 @@ class Samples(WeightedLabelledDataFrame):
             It is not advisible to plot an entire frame, as it is
             computationally expensive, and liable to run into linear algebra
             errors for degenerate derived parameters.
+
+        rasterize_scatter : bool, optional
+            Setting to True will rasterize just the scatter plots and leave
+            all other types of plots as vector images. 
+            Default is False. 
+            
 
         kind/kinds : dict, optional
             What kinds of plots to produce. Dictionary takes the keys
@@ -387,10 +393,13 @@ class Samples(WeightedLabelledDataFrame):
                             ax.set_xlabel(xlabel)
                             ax.set_ylabel(ylabel)
                         else:
+                            if rasterize_scatter == True and lkwargs['kind'] == 'scatter_2d':
+                                lkwargs['zorder'] = -1
                             self.plot(x, y, ax=ax, xlabel=xlabel,
                                       ylabel=ylabel, *args, **lkwargs)
                             ax.set_xlabel(xlabel)
                             ax.set_ylabel(ylabel)
+                            ax.set_rasterization_zorder(0)
                     else:
                         if x == y:
                             ax.twin.plot([], [])


### PR DESCRIPTION
# Description

Hi all. Opening this pull request mostly as a learning exercise. 

A while back when I was using anesthetic to produce figures for my first year report, I noticed that several of the pdf viewers I was using took a long time to load the scatter plots. For my report I ended up rasterizing just the scatter plots to render these as pngs while keeping everything else in the plot as vectors, and this made the plots much less 'sticky' when loading my pdf. At the time, Will suggested that this could be included as an option in anesthetic so I'm submitting this pull request. Let me know your thoughts - not sure where to proceed from here in terms of carrying out some of the below checklist items so any guidance on this would be appreciated.

Fixes # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both README.rst and anesthetic/_version.py
