### PR TITLE
added default rasterization to scatter_plot_2d()

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -1431,6 +1431,10 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
           effective samples in :func:`anesthetic.utils.neff`
           with ``beta=ncompress``.
 
+    Other Parameters
+    ----------------
+    **kwargs : rasterized = True (by default we rasterize scatter plots)
+
     Returns
     -------
     lines : :class:`matplotlib.lines.Line2D`
@@ -1454,10 +1458,10 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (ax._get_lines.get_next_color()
                                  if cmap is None else cmap(0.68)))
-
+    rasterized = kwargs.pop('raster', True) 
     kwargs.pop('q', None)
 
-    points = ax.plot(data_x, data_y, 'o', color=color, markersize=markersize,
+    points = ax.plot(data_x, data_y, 'o', color=color, markersize=markersize, rasterized=rasterized,
                      *args, **kwargs)
     return points
 


### PR DESCRIPTION
# Description

Hello all! Have created a new pull request for rasterizing scatter plots (and maybe other plot kinds too) as increasingly they take a long time to load on certain pdf viewers. This is an old pr but I accidentally closed the other one (lol). The rasterize setting is now embedded deeper in the code (in anesthetic/plot.py in the scatter_plot_2d() function) and rasterizing scatters has been made the default. I've also done away with z_orders as they were a bit awkward and I don't think we need them if we just use the matplotlib keyword argument 'rasterized'? Does anyone see an issue with doing it this way? Let me know your thoughts!

Fixes # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both README.rst and anesthetic/_version.py
