### PR TITLE
Fix compression for unweighted data to improve alpha transparency

### DIFF
--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -617,7 +617,23 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
             df = df.set_axis(self._get_axis(1-axis), axis=1-axis, copy=False)
             return df
         else:
-            return self
+            # For unweighted data, if ncompress is an integer > 0, randomly subsample
+            if isinstance(ncompress, int) and not isinstance(ncompress, bool) and ncompress > 0:
+                n_current = self.shape[axis]
+                if ncompress >= n_current:
+                    return self  # No need to compress if requested size >= current size
+                # Random subsample
+                np.random.seed(int(self._rand(axis).sum() * 1000) % 2**32)
+                if axis == 0:
+                    indices = np.random.choice(n_current, ncompress, replace=False)
+                    return self.iloc[indices]
+                else:
+                    indices = np.random.choice(n_current, ncompress, replace=False)
+                    return self.iloc[:, indices]
+            else:
+                # For other ncompress values (True, str, etc.) on unweighted data, 
+                # return self unchanged
+                return self
 
     def sample(self, *args, **kwargs):  # noqa: D102
         sig = signature(DataFrame.sample)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -1030,3 +1030,51 @@ def test_read_csv(tmp_path, mcmc_wdf):
     mcmc_wdf.to_csv(filename)
     mcmc_wdf_ = read_csv(filename)
     pandas.testing.assert_frame_equal(mcmc_wdf, mcmc_wdf_)
+
+
+def test_unweighted_dataframe_compression():
+    """Test that compression works for unweighted DataFrames with integer ncompress."""
+    # Create unweighted data
+    np.random.seed(42)
+    data = WeightedDataFrame(np.random.randn(1000, 3), columns=['A', 'B', 'C'])
+    assert not data.isweighted()
+    
+    # Test compression with integer values
+    for n in [100, 200, 500]:
+        compressed = data.compress(n)
+        assert len(compressed) == n
+        assert not compressed.isweighted()
+        assert list(compressed.columns) == list(data.columns)
+        
+    # Test compression with values >= original size (should return unchanged)
+    compressed = data.compress(1000)
+    assert len(compressed) == 1000
+    
+    compressed = data.compress(1500)
+    assert len(compressed) == 1000
+    
+    # Test compression with non-integer values (should return unchanged)
+    compressed = data.compress(True)
+    assert len(compressed) == 1000
+    
+    compressed = data.compress('equal')
+    assert len(compressed) == 1000
+    
+    compressed = data.compress(False)
+    assert len(compressed) == 1000
+
+
+def test_unweighted_compression_axis():
+    """Test compression with axis parameter for unweighted DataFrames."""
+    # Create unweighted data
+    np.random.seed(42)
+    data = WeightedDataFrame(np.random.randn(1000, 10))
+    assert not data.isweighted()
+    
+    # Test axis=0 (default - compress rows)
+    compressed = data.compress(100, axis=0)
+    assert compressed.shape == (100, 10)
+    
+    # Test axis=1 (compress columns)
+    compressed = data.compress(5, axis=1)
+    assert compressed.shape == (1000, 5)


### PR DESCRIPTION
## Summary
- Fixes Issue #400: Alpha transparency appearing ineffective in scatter plots
- The issue wasn't with alpha parameter itself, but with unweighted data compression not working
- Integer values for `ncompress` now properly subsample unweighted DataFrames
- This reduces point overlaps, making alpha transparency visually effective

## Changes
- Enhanced `WeightedDataFrame.compress()` method to handle unweighted data with integer `ncompress` values
- Added random subsampling for unweighted data when `ncompress` is a positive integer
- Added comprehensive tests for unweighted data compression functionality
- Maintains backward compatibility for all existing compression behaviors

## Test plan
- [x] Added tests for unweighted DataFrame compression with integer values
- [x] Added tests for compression with axis parameter
- [x] Verified compression works for values >= original size
- [x] Verified non-integer ncompress values return unchanged data
- [x] All existing tests continue to pass

Fixes #400

🤖 Generated with [Claude Code](https://claude.ai/code)